### PR TITLE
Use System.IO.Abstractions for mock tests

### DIFF
--- a/Sizy.Tests/Sizy.Tests.fsproj
+++ b/Sizy.Tests/Sizy.Tests.fsproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <PackageReference Include="FsUnit.xUnit" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="9.0.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="coverlet.collector" Version="1.1.0" />

--- a/Sizy.Tests/Tests.fs
+++ b/Sizy.Tests/Tests.fs
@@ -31,6 +31,7 @@ module ``Sizy Test`` =
         |> Map.ofSeq
         |> MockFileSystem
 
+    let MockFsRootFolder = """/test"""
 
     let createTestFolder nBytes =
         let tmpPath = Path.GetTempPath()
@@ -44,7 +45,7 @@ module ``Sizy Test`` =
             remBytes <- remBytes - bytes
         rootFolder
 
-    let getSizeStringTestData: Object [] [] =
+    let getSizeUnitTestData: Object [] [] =
         [| [| -12345; 0.0; "B" |]
            [| 0; 0.0; "B" |]
            [| 1024; 1.0; "k" |]
@@ -63,18 +64,19 @@ module ``Sizy Test`` =
         let numWrittenBytes = r.Next MaxNumBytes
         let rootFolder = createTestFolder numWrittenBytes
         let fs = new FileSystem()
-        Program.sizyMain (fs, rootFolder) |> should equal (float numWrittenBytes)
+        let _, _, totSize, _ = Program.sizyMain (fs, rootFolder)
+        totSize |> should equal (int64 numWrittenBytes)
         Directory.Delete(rootFolder, true)
 
     [<Fact>]
     let checkTotalSizeMock() =
-        let rootFolder = """/test"""
-        Program.sizyMain (MockFs, rootFolder) |> should equal (float TestFileContent.Length)
+        let _, _, totSize, _ = Program.sizyMain (MockFs, MockFsRootFolder)
+        totSize |> should equal (int64 TestFileContent.Length)
 
     [<Theory>]
-    [<MemberData("getSizeStringTestData")>]
-    let getSizeString (input: int64, outSize: float, outUnit: string) =
-        Program.getSizeString input |> should equal (outSize, outUnit)
+    [<MemberData("getSizeUnitTestData")>]
+    let getSizeUnit (input: int64, outSize: float, outUnit: string) =
+        Program.getSizeUnit input |> should equal (outSize, outUnit)
 
 
     [<EntryPoint>]

--- a/Sizy/Sizy.fsproj
+++ b/Sizy/Sizy.fsproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Argu" Version="6.0.0" />
     <PackageReference Include="Fsharp.Collections.ParallelSeq" Version="1.1.2" />
+    <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 - improve overall testability by separating pure and impure functions as much as possible
 - use System.IO.Abstractions to mock file system