### PR TITLE
Improve performance of getSizeUnit function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ project.lock.json
 
 # Visual Studio Code
 .vscode
+.ionide
 
 # User-specific files
 *.suo
@@ -27,6 +28,9 @@ bld/
 msbuild.log
 msbuild.err
 msbuild.wrn
+
+# BenchmarkDotNet
+BenchmarkDotNet.Artifacts
 
 # Visual Studio 2015
 .vs/

--- a/Sizy.Tests/Benchmarks.fs
+++ b/Sizy.Tests/Benchmarks.fs
@@ -1,0 +1,25 @@
+//namespace Sizy.Benchmarks
+
+open BenchmarkDotNet.Running
+open BenchmarkDotNet.Attributes
+
+open Sizy
+
+type Benchmarks () =
+    [<ParamsSource("NBytesValues")>]
+    member val public NBytes = 0L with get, set
+
+    member val public NBytesValues = seq {0L .. 10010L .. 100000L}
+
+    [<Benchmark>]
+    member this.GetSizeUnit () = Program.getSizeUnit(this.NBytes) |> ignore
+
+    [<Benchmark>]
+    member this.GetSizeUnit2 () = Program.getSizeUnit2(this.NBytes) |> ignore
+
+    
+[<EntryPoint>]
+let main argv =
+    BenchmarkRunner.Run<Benchmarks>() |> ignore
+    0
+    

--- a/Sizy.Tests/Benchmarks.fs
+++ b/Sizy.Tests/Benchmarks.fs
@@ -1,9 +1,9 @@
-//namespace Sizy.Benchmarks
+namespace Sizy.Benchmarks
 
 open BenchmarkDotNet.Running
 open BenchmarkDotNet.Attributes
 
-open Sizy
+open Sizy.Program
 
 type Benchmarks () =
     [<ParamsSource("NBytesValues")>]
@@ -12,14 +12,11 @@ type Benchmarks () =
     member val public NBytesValues = seq {0L .. 10010L .. 100000L}
 
     [<Benchmark>]
-    member this.GetSizeUnit () = Program.getSizeUnit(this.NBytes) |> ignore
+    member this.GetSizeUnit () = getSizeUnit(this.NBytes) |> ignore
 
-    [<Benchmark>]
-    member this.GetSizeUnit2 () = Program.getSizeUnit2(this.NBytes) |> ignore
-
-    
-[<EntryPoint>]
-let main argv =
-    BenchmarkRunner.Run<Benchmarks>() |> ignore
-    0
+module Program =
+    [<EntryPoint>]
+    let main argv =
+        BenchmarkRunner.Run<Benchmarks>() |> ignore
+        0
     

--- a/Sizy.Tests/Sizy.Tests.fsproj
+++ b/Sizy.Tests/Sizy.Tests.fsproj
@@ -9,9 +9,11 @@
 
   <ItemGroup>
     <Compile Include="Tests.fs" />
+    <Compile Include="Benchmarks.fs" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="FsUnit.xUnit" Version="3.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="System.IO.Abstractions" Version="9.0.4" />

--- a/Sizy.Tests/Tests.fs
+++ b/Sizy.Tests/Tests.fs
@@ -77,7 +77,3 @@ module ``Sizy Test`` =
     [<MemberData("getSizeUnitTestData")>]
     let getSizeUnit (input: int64, outSize: float, outUnit: string) =
         Program.getSizeUnit input |> should equal (outSize, outUnit)
-
-
-    [<EntryPoint>]
-    let main _ = 0

--- a/Sizy/Config.fs
+++ b/Sizy/Config.fs
@@ -16,7 +16,7 @@ type Args =
             match s with
             | Version _ -> sprintf "print %s version." PROGRAM_NAME
             | Percentage _ -> "show percentage values"
-            | InputPath _ -> "the folder you want to analise"
+            | InputPath _ -> "the folder you want to analyse"
 
 type ConfigOrInt =
     | Config of Argu.ParseResults<Args>

--- a/Sizy/Program.fs
+++ b/Sizy/Program.fs
@@ -40,7 +40,7 @@ let sizyMain (fs: IFileSystem, path: string) =
     let totSize = PSeq.sum sizes
     ls, fsEntries, totSize, errors
 
-let getSizeUnit bytes =
+let getSizeUnit2 bytes =
     if bytes <= 0L then
         0.0, SizeUnits.[0]
     else
@@ -48,6 +48,24 @@ let getSizeUnit bytes =
         let sizeUnitsIdx = Math.Floor(Math.Log(bytesF, 1024.0))
         let num = Math.Round(bytesF / Math.Pow(1024.0, sizeUnitsIdx), 0)
         num, SizeUnits.[int (sizeUnitsIdx)]
+
+let getSizeUnit bytes =
+    if bytes <= 0L then
+        0.0, SizeUnits.[0]
+    elif bytes >= 0x1000000000000000L then
+        Math.Round(float(bytes >>> 50) / 1024.0, 0), SizeUnits.[6]
+    elif bytes >= 0x4000000000000L then
+        Math.Round(float(bytes >>> 40) / 1024.0), SizeUnits.[5]
+    elif bytes >= 0x10000000000L then
+        Math.Round(float(bytes >>> 30) / 1024.0), SizeUnits.[4]
+    elif bytes >= 0x40000000L then
+        Math.Round(float(bytes >>> 20) / 1024.0), SizeUnits.[3]
+    elif bytes >= 0x100000L then
+        Math.Round(float(bytes >>> 10) / 1024.0), SizeUnits.[2]
+    elif bytes >= 0x400L then
+        Math.Round(float(bytes) / 1024.0), SizeUnits.[1]
+    else
+        float(bytes), SizeUnits.[0]
 
 let getSizeString name size =
     let newSize, sizeUnit = getSizeUnit size


### PR DESCRIPTION
The new `getSizeUnit` function uses bit shift operations instead of Math.Pow, Math.Log, etc, and appears to be up to almost 4x faster.

Credits: https://www.somacon.com/p576.php

``sudo dotnet run -c Release --framework netcoreapp3.1``

``` ini

BenchmarkDotNet=v0.12.0, OS=arch 
Intel Core i5-7200U CPU 2.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=3.1.103
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT DEBUG
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|       Method | NBytes |     Mean |    Error |    StdDev |   Median |
|------------- |------- |---------:|---------:|----------:|---------:|
|  **GetSizeUnit** |      **0** | **14.79 ns** | **0.332 ns** |  **0.828 ns** | **14.51 ns** |
| GetSizeUnit2 |      0 | 18.22 ns | 0.900 ns |  2.596 ns | 17.64 ns |
|  **GetSizeUnit** |  **10010** | **27.27 ns** | **1.045 ns** |  **3.033 ns** | **26.53 ns** |
| GetSizeUnit2 |  10010 | 86.79 ns | 1.742 ns |  3.052 ns | 86.90 ns |
|  **GetSizeUnit** |  **20020** | **26.60 ns** | **1.272 ns** |  **3.610 ns** | **25.98 ns** |
| GetSizeUnit2 |  20020 | 99.43 ns | 5.018 ns | 14.796 ns | 95.34 ns |
|  **GetSizeUnit** |  **30030** | **30.99 ns** | **1.970 ns** |  **5.810 ns** | **29.17 ns** |
| GetSizeUnit2 |  30030 | 97.80 ns | 3.663 ns | 10.627 ns | 94.70 ns |
|  **GetSizeUnit** |  **40040** | **28.73 ns** | **1.992 ns** |  **5.872 ns** | **26.28 ns** |
| GetSizeUnit2 |  40040 | 86.64 ns | 1.754 ns |  2.625 ns | 88.17 ns |
|  **GetSizeUnit** |  **50050** | **26.23 ns** | **0.781 ns** |  **2.240 ns** | **25.17 ns** |
| GetSizeUnit2 |  50050 | 89.46 ns | 1.825 ns |  4.083 ns | 89.84 ns |
|  **GetSizeUnit** |  **60060** | **26.45 ns** | **0.823 ns** |  **2.336 ns** | **25.25 ns** |
| GetSizeUnit2 |  60060 | 86.02 ns | 1.756 ns |  2.885 ns | 85.15 ns |
|  **GetSizeUnit** |  **70070** | **22.63 ns** | **1.090 ns** |  **3.213 ns** | **20.87 ns** |
| GetSizeUnit2 |  70070 | 86.58 ns | 1.774 ns |  2.864 ns | 86.20 ns |
|  **GetSizeUnit** |  **80080** | **26.10 ns** | **0.930 ns** |  **1.579 ns** | **25.95 ns** |
| GetSizeUnit2 |  80080 | 89.28 ns | 1.830 ns |  4.522 ns | 89.07 ns |
|  **GetSizeUnit** |  **90090** | **31.68 ns** | **1.889 ns** |  **5.569 ns** | **30.56 ns** |
| GetSizeUnit2 |  90090 | 86.25 ns | 1.751 ns |  3.158 ns | 85.64 ns |
