### PR TITLE
Fix: env var command in GitHub actions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -48,7 +48,8 @@ jobs:
       run: |
         export SHA=${GITHUB_SHA:0:7}
         dotnet publish -c Debug -o ./${{ env.project_name }}-dev-$SHA
-        echo ::set-env name=SHA::"${GITHUB_SHA:0:7}"
+        echo SHA=${GITHUB_SHA:0:7} >> $GITHUB_ENV
+        
     - name: Upload debug artifact
       uses: actions/upload-artifact@v1.0.0
       with:


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/